### PR TITLE
chore: Add Dependabot for npm

### DIFF
--- a/Example/.github/dependabot.yml
+++ b/Example/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "09:00"
+      timezone: Asia/Tokyo


### PR DESCRIPTION
I added `Dependabot` for npm to check the versions of libraries.

- Close: https://github.com/dev-yakuza/react-native-image-modal/issues/79