### PR TITLE
chore: Fix wrong version variable name in GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: npm install
       - name: Update package.json version
-        run: npm version ${{ steps.semver.outputs.version }} --no-git-tag-version
+        run: npm version ${{ steps.version.outputs.version }} --no-git-tag-version
       - name: Commit package.json
         run: |
           git config user.email "dev.yakuza@gmail.com"


### PR DESCRIPTION
I fix the wrong version variable name in the GitHub Actions for release.