### PR TITLE
chore: Add registry-url to fix authorization error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.11.1
+          registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: npm install
       - name: Update package.json version


### PR DESCRIPTION
I add the `registry-url` to fix the authorization error of NPM.

- https://github.com/dev-yakuza/react-native-image-modal/actions/runs/9235324344/job/25410013996