### PR TITLE
chore: Add --allow-same-version to fix GitHub Actions error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: npm install
       - name: Update package.json version
-        run: npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+        run: npm version ${{ steps.version.outputs.version }} --no-git-tag-version --allow-same-version
       - name: Commit package.json
         run: |
           git config user.email "dev.yakuza@gmail.com"


### PR DESCRIPTION
I add the `--allow-same-version` to fix the `GitHub Actions error.

- https://github.com/dev-yakuza/react-native-image-modal/actions/runs/9235359000/job/25410087677