### PR TITLE
chore: Remove wrong setting of release drafter

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,6 @@ jobs:
       # For release notes
       - uses: release-drafter/release-drafter@v6
         with:
-          config-name: release-drafter-for-word.yml
           tag: ${{ steps.version.outputs.version }}
           name: ${{ steps.version.outputs.version }}
           version: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
I remove the wrong setting of Release Drafter to fix GitHub Actions error.

- https://github.com/dev-yakuza/react-native-image-modal/actions/runs/9235586819/job/25410544538