### PR TITLE
fix: Remove postinstall to fix error

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Install libraries.
 
 ```bash
 npm install
+npx lefthook install
 ```
 
 Execute the following command to start the project.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "prepare": "rm -rf dist && tsc",
-    "postinstall": "lefthook install",
     "lint": "eslint --ext .tsx --ext .ts src/",
     "format": "prettier --check ./src",
     "cspell": "cspell '**' --gitignore --show-suggestions",


### PR DESCRIPTION
I remove the `postinstall` in the `package.json` file to fix the following error.

<img width="887" alt="Screenshot 2024-06-12 at 13 19 11" src="https://github.com/dev-yakuza/react-native-image-modal/assets/167288055/821ba06c-4246-4991-8edf-d2f181b77382">

- Related: https://github.com/dev-yakuza/react-native-image-modal/issues/132#issuecomment-2162193873