### PR TITLE
refactor: Use timing instead spring for duration

### DIFF
--- a/src/ImageDetail/index.tsx
+++ b/src/ImageDetail/index.tsx
@@ -137,9 +137,10 @@ const ImageDetail = forwardRef<ImageDetail, Props>(
             useNativeDriver: false,
             duration: animationDuration * 2,
           }),
-          Animated.spring(_animatedFrame, {
+          Animated.timing(_animatedFrame, {
             toValue: 0,
             useNativeDriver: false,
+            duration: animationDuration,
           }),
         ]).start(() => {
           onClose()
@@ -173,9 +174,10 @@ const ImageDetail = forwardRef<ImageDetail, Props>(
           useNativeDriver: false,
           duration: animationDuration * 2,
         }),
-        Animated.spring(_animatedFrame, {
+        Animated.timing(_animatedFrame, {
           toValue: 1,
           useNativeDriver: false,
+          duration: animationDuration,
         }),
       ]).start(() => {
         _isAnimated.current = false


### PR DESCRIPTION
I refactor using the `timing` instead of the `spring` for the duration of the animation.