### PR TITLE
docs: Remove react-native-fast-image from readme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,17 @@ There are blog posts about how to use `react-native-image-modal`.
 
 ## Installation
 
-This library use `react-native-fast-image`, so you need to install it.
+Execute the command to install `react-native-image-modal`.
 
 ```bash
-npm install --save react-native-fast-image
-npx pod-install
-```
-
-And then execute the command to install `react-native-image-modal`.
-
-```bash
+# npm
 npm install --save react-native-image-modal
+
+# yarn
+yarn add --dev react-native-image-modal
+
+# pnpm
+pnpm add --save react-native-image-modal
 ```
 
 ## How to use


### PR DESCRIPTION
This library doesn't need the `react-native-fast-image` anymore.

- PR: https://github.com/dev-yakuza/react-native-image-modal/pull/240#

But, the document is not updated. So, I update the wrong document.