### PR TITLE
fix: Fix property React doesn't exist error

### DIFF
--- a/src/components/ImageDetail/components/Background/index.tsx
+++ b/src/components/ImageDetail/components/Background/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import type { ColorValue } from 'react-native'
 import { Animated, StyleSheet } from 'react-native'
 

--- a/src/components/ImageDetail/components/DisplayImageArea/index.tsx
+++ b/src/components/ImageDetail/components/DisplayImageArea/index.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react'
-import React from 'react'
 import { Animated, Dimensions, Platform, StatusBar, StyleSheet } from 'react-native'
 
 const styles = StyleSheet.create({

--- a/src/components/ImageDetail/components/Footer/index.tsx
+++ b/src/components/ImageDetail/components/Footer/index.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react'
-import React from 'react'
 import { Animated, StyleSheet } from 'react-native'
 
 const styles = StyleSheet.create({

--- a/src/components/ImageDetail/components/Header/index.tsx
+++ b/src/components/ImageDetail/components/Header/index.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react'
-import React from 'react'
 import { Animated, SafeAreaView, StatusBar, StyleSheet, Text, TouchableOpacity } from 'react-native'
 
 const styles = StyleSheet.create({

--- a/src/components/ImageDetail/index.tsx
+++ b/src/components/ImageDetail/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
 import type { ImageResizeMode, StyleProp, ImageStyle, ImageSourcePropType } from 'react-native'
 import { Dimensions, Animated, Modal } from 'react-native'
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode, RefObject } from 'react'
-import React, { createRef, forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import { createRef, forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import type { StyleProp, ImageStyle, ImageResizeMode, ImageSourcePropType } from 'react-native'
 import { Animated, View } from 'react-native'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["es6", "dom", "es2016", "es2017"],
     "sourceMap": true,
     "allowJs": false,
-    "jsx": "react-native",
+    "jsx": "react-jsx",
     "declaration": true,
     "declarationMap": true,
     "moduleResolution": "node",


### PR DESCRIPTION
I fix the property React doesn't exist error.

- Related: https://github.com/birkir/react-native-sfsymbols/pull/18
- Close: https://github.com/dev-yakuza/react-native-image-modal/issues/425